### PR TITLE
feat(static-rules): implement static analysis rules API with JSON

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,9 +11,8 @@ from app.routers.instructor_io_tests import router as instructor_io_tests_router
 from app.routers.web_instructor_io_tests import router as web_instructor_io_tests_router
 from app.routers.instructor_unit_tests import router as instructor_unit_tests_router
 from app.routers.web_instructor_unit_tests import router as web_instructor_unit_tests_router
-
-
-
+from app.routers.instructor_static_rules import router as instructor_static_rules_router
+from app.routers.web_instructor_static_rules import router as web_instructor_static_rules_router
 
 settings = get_settings()
 setup_logging(settings.log_level)
@@ -31,5 +30,6 @@ app.include_router(instructor_io_tests_router)
 app.include_router(web_instructor_io_tests_router)
 app.include_router(instructor_unit_tests_router)
 app.include_router(web_instructor_unit_tests_router)
-
+app.include_router(instructor_static_rules_router)
+app.include_router(web_instructor_static_rules_router)
 

--- a/app/routers/instructor_static_rules.py
+++ b/app/routers/instructor_static_rules.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.dependencies.auth import require_instructor
+from app.models.models import Assignment, StaticRule
+from app.schemas.static_rule import StaticRuleUpsert, StaticRuleOut
+
+router = APIRouter(
+    prefix="/instructor/assignments",
+    tags=["instructor-static-rules"],
+)
+
+
+def _get_owned_assignment(db: Session, assignment_id: int, instructor_id: int) -> Assignment:
+    assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
+    if not assignment:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+    if assignment.instructor_id != instructor_id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return assignment
+
+
+@router.put(
+    "/{assignment_id}/static-rules",
+    response_model=StaticRuleOut,
+)
+def upsert_static_rules(
+    assignment_id: int,
+    payload: StaticRuleUpsert,
+    db: Session = Depends(get_db),
+    instructor=Depends(require_instructor),
+):
+    _get_owned_assignment(db, assignment_id, instructor.id)
+
+    rule = db.query(StaticRule).filter(StaticRule.assignment_id == assignment_id).first()
+
+    if rule:
+        rule.required_functions = payload.required_functions
+        rule.forbidden_imports = payload.forbidden_imports
+        rule.max_cyclomatic_complexity = payload.max_cyclomatic_complexity
+        rule.points = payload.points
+        db.commit()
+        db.refresh(rule)
+        return rule
+
+    rule = StaticRule(
+        assignment_id=assignment_id,
+        required_functions=payload.required_functions,
+        forbidden_imports=payload.forbidden_imports,
+        max_cyclomatic_complexity=payload.max_cyclomatic_complexity,
+        points=payload.points,
+    )
+    db.add(rule)
+    db.commit()
+    db.refresh(rule)
+    return rule
+
+
+@router.get(
+    "/{assignment_id}/static-rules",
+    response_model=StaticRuleOut,
+)
+def get_static_rules(
+    assignment_id: int,
+    db: Session = Depends(get_db),
+    instructor=Depends(require_instructor),
+):
+    _get_owned_assignment(db, assignment_id, instructor.id)
+
+    rule = db.query(StaticRule).filter(StaticRule.assignment_id == assignment_id).first()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Static rules not found")
+    return rule

--- a/app/routers/web_instructor_static_rules.py
+++ b/app/routers/web_instructor_static_rules.py
@@ -1,0 +1,155 @@
+import json
+import httpx
+from jose import jwt, JWTError
+from fastapi import APIRouter, Request
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import RedirectResponse, HTMLResponse
+
+from app.config import settings
+
+router = APIRouter(prefix="/web", tags=["web-static-rules"])
+templates = Jinja2Templates(directory="app/templates")
+
+COOKIE_NAME = "access_token"
+
+
+def get_api_base_url(request: Request) -> str:
+    return str(request.base_url).rstrip("/")
+
+
+def _normalize_role(role_value):
+    if role_value is None:
+        return None
+    if isinstance(role_value, str):
+        return role_value
+    if isinstance(role_value, (list, tuple)) and role_value:
+        return role_value[0] if isinstance(role_value[0], str) else None
+    return None
+
+
+def get_user_from_cookie(request: Request):
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        role = _normalize_role(payload.get("role") or payload.get("user_role") or payload.get("roles"))
+        return {"role": role, "token": token}
+    except JWTError:
+        return None
+
+
+def require_instructor_web(request: Request):
+    user = get_user_from_cookie(request)
+    if not user:
+        return None, RedirectResponse(url="/login", status_code=303)
+    if user.get("role") != "instructor":
+        return None, templates.TemplateResponse(
+            "forbidden.html",
+            {"request": request, "message": "Instructor access only."},
+            status_code=403,
+        )
+    return user, None
+
+
+@router.get("/instructor/assignments/{assignment_id}/static-rules", response_class=HTMLResponse)
+async def static_rules_page(request: Request, assignment_id: int):
+    user, resp = require_instructor_web(request)
+    if resp:
+        return resp
+
+    api_base = get_api_base_url(request)
+
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            f"{api_base}/instructor/assignments/{assignment_id}/static-rules",
+            headers={"Authorization": f"Bearer {user['token']}"},
+        )
+
+    rule = None
+    if r.status_code == 200:
+        rule = r.json()
+    elif r.status_code != 404:
+        return templates.TemplateResponse(
+            "forbidden.html",
+            {"request": request, "message": "Unable to load static rules."},
+            status_code=r.status_code,
+        )
+
+    # Provide a nice JSON textarea default
+    default_json = json.dumps(
+        rule
+        or {
+            "required_functions": ["solve"],
+            "forbidden_imports": ["os", "sys"],
+            "max_cyclomatic_complexity": 10,
+            "points": 0,
+        },
+        indent=2,
+    )
+
+    return templates.TemplateResponse(
+        "static_rules.html",
+        {
+            "request": request,
+            "assignment_id": assignment_id,
+            "rule": rule,
+            "json_text": default_json,
+            "error": None,
+        },
+    )
+
+
+@router.post("/instructor/assignments/{assignment_id}/static-rules")
+async def static_rules_submit(request: Request, assignment_id: int):
+    user, resp = require_instructor_web(request)
+    if resp:
+        return resp
+
+    form = await request.form()
+    json_text = str(form.get("json_text", "")).strip()
+
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as e:
+        return templates.TemplateResponse(
+            "static_rules.html",
+            {
+                "request": request,
+                "assignment_id": assignment_id,
+                "rule": None,
+                "json_text": json_text,
+                "error": f"Invalid JSON: {e.msg}",
+            },
+            status_code=400,
+        )
+
+    api_base = get_api_base_url(request)
+
+    async with httpx.AsyncClient() as client:
+        r = await client.put(
+            f"{api_base}/instructor/assignments/{assignment_id}/static-rules",
+            json=payload,
+            headers={"Authorization": f"Bearer {user['token']}"},
+        )
+
+    if r.status_code >= 400:
+        detail = None
+        try:
+            detail = r.json().get("detail")
+        except Exception:
+            detail = r.text
+
+        return templates.TemplateResponse(
+            "static_rules.html",
+            {
+                "request": request,
+                "assignment_id": assignment_id,
+                "rule": None,
+                "json_text": json_text,
+                "error": detail or "Failed to save static rules.",
+            },
+            status_code=400,
+        )
+
+    return RedirectResponse(url=f"/web/instructor/assignments/{assignment_id}/static-rules", status_code=303)

--- a/app/schemas/static_rule.py
+++ b/app/schemas/static_rule.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field, ConfigDict
+from typing import Optional, List
+
+
+class StaticRuleUpsert(BaseModel):
+    required_functions: Optional[List[str]] = None
+    forbidden_imports: Optional[List[str]] = None
+    max_cyclomatic_complexity: Optional[int] = Field(default=None, ge=1, le=10_000)
+    points: int = Field(default=0, ge=0, le=100_000)
+
+
+class StaticRuleOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    assignment_id: int
+    required_functions: Optional[list[str]]
+    forbidden_imports: Optional[list[str]]
+    max_cyclomatic_complexity: Optional[int]
+    points: int

--- a/app/templates/instructor_dashboard.html
+++ b/app/templates/instructor_dashboard.html
@@ -29,7 +29,8 @@
       <td>
         <a href="/web/instructor/assignments/{{ a.id }}/edit">Edit</a> |
         <a href="/web/instructor/assignments/{{ a.id }}/io-tests">IO Tests</a> |
-        <a href="/web/instructor/assignments/{{ a.id }}/unit-tests">Unit Tests</a>
+        <a href="/web/instructor/assignments/{{ a.id }}/unit-tests">Unit Tests</a>|
+        <a href="/web/instructor/assignments/{{ a.id }}/static-rules">Static Rules</a>
       </td>
     </tr>
     {% endfor %}

--- a/app/templates/static_rules.html
+++ b/app/templates/static_rules.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Static Rules - Assignment {{ assignment_id }}</h2>
+
+{% if error %}
+  <div class="error">{{ error }}</div>
+{% endif %}
+
+<form method="post" action="/web/instructor/assignments/{{ assignment_id }}/static-rules">
+  <label>Static rules (JSON)</label>
+  <textarea name="json_text" rows="14" style="width: 100%;">{{ json_text }}</textarea>
+  <button type="submit">Save Static Rules</button>
+</form>
+
+<hr />
+
+<h3>Saved Static Rules</h3>
+
+{% if not rule %}
+  <p class="muted">No static rules saved yet.</p>
+{% else %}
+  <pre style="white-space: pre-wrap;">{{ rule | tojson(indent=2) }}</pre>
+{% endif %}
+
+<p><a href="/web/instructor/dashboard">Back to Dashboard</a></p>
+{% endblock %}


### PR DESCRIPTION
…rage

- Added endpoint to create/update static rules per assignment
- Added endpoint to retrieve static rules
- Enforced single static rule configuration per assignment
- Implemented JSON-based rule storage in database
- Added validation for required_functions, forbidden_imports, and max_cyclomatic_complexity
- Enforced instructor-only access control
- Added Jinja templates for instructor UI
- Ensured compatibility with JSON-based API requests

Static rule configuration is now ready for integration with grading engine.