### PR TITLE
feat(assignments): add publish assignment workflow with instructor-on…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,10 @@ from app.routers.instructor_unit_tests import router as instructor_unit_tests_ro
 from app.routers.web_instructor_unit_tests import router as web_instructor_unit_tests_router
 from app.routers.instructor_static_rules import router as instructor_static_rules_router
 from app.routers.web_instructor_static_rules import router as web_instructor_static_rules_router
+from app.routers.student_assignments import router as student_assignments_router
+from app.routers.web_instructor_publish import router as web_instructor_publish_router
+from app.routers.web_student_dashboard import router as web_student_dashboard_router
+
 
 settings = get_settings()
 setup_logging(settings.log_level)
@@ -32,4 +36,8 @@ app.include_router(instructor_unit_tests_router)
 app.include_router(web_instructor_unit_tests_router)
 app.include_router(instructor_static_rules_router)
 app.include_router(web_instructor_static_rules_router)
+app.include_router(student_assignments_router)
+app.include_router(web_instructor_publish_router)
+app.include_router(web_student_dashboard_router)
+
 

--- a/app/routers/instructor_assignments.py
+++ b/app/routers/instructor_assignments.py
@@ -1,68 +1,3 @@
-# from fastapi import APIRouter, Depends, HTTPException, status
-# from sqlalchemy.orm import Session
-
-# from app.schemas.assignment import AssignmentCreate, AssignmentUpdate, AssignmentOut
-# from app.models.models import Assignment
-# from app.dependencies.db import get_db
-# from app.dependencies.auth import require_instructor
-
-# router = APIRouter(prefix="/instructor/assignments", tags=["instructor-assignments"])
-
-
-# @router.post("", response_model=AssignmentOut, status_code=status.HTTP_201_CREATED)
-# def create_assignment(
-#     payload: AssignmentCreate,
-#     db: Session = Depends(get_db),
-#     instructor=Depends(require_instructor),
-# ):
-#     assignment = Assignment(
-#         instructor_id=instructor.id,
-#         title=payload.title,
-#         description=payload.description,
-#         instructions=payload.instructions,
-#         language=payload.language,
-#         is_published=payload.is_published,
-#         weight_io=payload.weight_io,
-#         weight_unit=payload.weight_unit,
-#         weight_static=payload.weight_static,
-#         max_runtime_ms=payload.max_runtime_ms,
-#         max_memory_kb=payload.max_memory_kb,
-#     )
-#     db.add(assignment)
-#     db.commit()
-#     db.refresh(assignment)
-#     return assignment
-
-
-# @router.put("/{assignment_id}", response_model=AssignmentOut)
-# def update_assignment(
-#     assignment_id: int,
-#     payload: AssignmentUpdate,
-#     db: Session = Depends(get_db),
-#     instructor=Depends(require_instructor),
-# ):
-#     assignment: Assignment | None = (
-#         db.query(Assignment)
-#         .filter(Assignment.id == assignment_id)
-#         .first()
-#     )
-#     if not assignment:
-#         raise HTTPException(status_code=404, detail="Assignment not found")
-
-#     # Only the owner instructor can edit
-#     if assignment.instructor_id != instructor.id:
-#         raise HTTPException(status_code=403, detail="Not allowed to edit this assignment")
-
-#     data = payload.model_dump(exclude_unset=True)
-
-#     for k, v in data.items():
-#         setattr(assignment, k, v)
-
-#     db.commit()
-#     db.refresh(assignment)
-#     return assignment
-
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -187,5 +122,50 @@ def get_assignment(
 
     if assignment.instructor_id != instructor.id:
         raise HTTPException(status_code=403, detail="Not allowed")
+
+    return assignment
+
+@router.post("/{assignment_id}/publish", response_model=AssignmentOut)
+def publish_assignment(
+    assignment_id: int,
+    db: Session = Depends(get_db),
+    instructor=Depends(require_instructor),
+):
+    assignment = (
+        db.query(Assignment)
+        .filter(Assignment.id == assignment_id)
+        .first()
+    )
+    if not assignment:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+
+    if assignment.instructor_id != instructor.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    if not assignment.is_published:
+        assignment.is_published = True
+        db.commit()
+        db.refresh(assignment)
+
+    return assignment
+
+
+@router.post("/{assignment_id}/unpublish", response_model=AssignmentOut)
+def unpublish_assignment(
+    assignment_id: int,
+    db: Session = Depends(get_db),
+    instructor=Depends(require_instructor),
+):
+    assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
+    if not assignment:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+
+    if assignment.instructor_id != instructor.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    if assignment.is_published:
+        assignment.is_published = False
+        db.commit()
+        db.refresh(assignment)
 
     return assignment

--- a/app/routers/student_assignments.py
+++ b/app/routers/student_assignments.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.dependencies.auth import require_student
+from app.models.models import Assignment
+from app.schemas.assignment import AssignmentOut
+
+router = APIRouter(prefix="/student/assignments", tags=["student-assignments"])
+
+
+@router.get("", response_model=list[AssignmentOut])
+def list_published_assignments(
+    db: Session = Depends(get_db),
+    student=Depends(require_student),
+):
+    return (
+        db.query(Assignment)
+        .filter(Assignment.is_published == True)  # noqa: E712
+        .order_by(Assignment.created_at.desc())
+        .all()
+    )

--- a/app/routers/web_instructor_publish.py
+++ b/app/routers/web_instructor_publish.py
@@ -1,0 +1,85 @@
+import httpx
+from jose import jwt, JWTError
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from app.config import settings
+
+router = APIRouter(prefix="/web", tags=["web-publish"])
+templates = Jinja2Templates(directory="app/templates")
+
+COOKIE_NAME = "access_token"
+
+
+def get_api_base_url(request: Request) -> str:
+    return str(request.base_url).rstrip("/")
+
+
+def _normalize_role(role_value):
+    if role_value is None:
+        return None
+    if isinstance(role_value, str):
+        return role_value
+    if isinstance(role_value, (list, tuple)) and role_value:
+        return role_value[0] if isinstance(role_value[0], str) else None
+    return None
+
+
+def get_user_from_cookie(request: Request):
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        role = _normalize_role(payload.get("role") or payload.get("user_role") or payload.get("roles"))
+        return {"role": role, "token": token}
+    except JWTError:
+        return None
+
+
+def require_instructor_web(request: Request):
+    user = get_user_from_cookie(request)
+    if not user:
+        return None, RedirectResponse(url="/login", status_code=303)
+    if user.get("role") != "instructor":
+        return None, templates.TemplateResponse(
+            "forbidden.html",
+            {"request": request, "message": "Instructor access only."},
+            status_code=403,
+        )
+    return user, None
+
+
+@router.post("/instructor/assignments/{assignment_id}/publish")
+async def publish_assignment_web(request: Request, assignment_id: int):
+    user, resp = require_instructor_web(request)
+    if resp:
+        return resp
+
+    api_base = get_api_base_url(request)
+
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            f"{api_base}/instructor/assignments/{assignment_id}/publish",
+            headers={"Authorization": f"Bearer {user['token']}"},
+        )
+
+    return RedirectResponse(url="/web/instructor/dashboard", status_code=303)
+
+
+@router.post("/instructor/assignments/{assignment_id}/unpublish")
+async def unpublish_assignment_web(request: Request, assignment_id: int):
+    user, resp = require_instructor_web(request)
+    if resp:
+        return resp
+
+    api_base = get_api_base_url(request)
+
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            f"{api_base}/instructor/assignments/{assignment_id}/unpublish",
+            headers={"Authorization": f"Bearer {user['token']}"},
+        )
+
+    return RedirectResponse(url="/web/instructor/dashboard", status_code=303)

--- a/app/routers/web_student_dashboard.py
+++ b/app/routers/web_student_dashboard.py
@@ -1,0 +1,61 @@
+import httpx
+from jose import jwt, JWTError
+from fastapi import APIRouter, Request
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import RedirectResponse, HTMLResponse
+
+from app.config import settings
+
+router = APIRouter(prefix="/web", tags=["web-student"])
+templates = Jinja2Templates(directory="app/templates")
+
+COOKIE_NAME = "access_token"
+
+
+def get_api_base_url(request: Request) -> str:
+    return str(request.base_url).rstrip("/")
+
+
+def _normalize_role(role_value):
+    if role_value is None:
+        return None
+    if isinstance(role_value, str):
+        return role_value
+    if isinstance(role_value, (list, tuple)) and role_value:
+        return role_value[0] if isinstance(role_value[0], str) else None
+    return None
+
+
+def get_user_from_cookie(request: Request):
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        role = _normalize_role(payload.get("role") or payload.get("user_role") or payload.get("roles"))
+        return {"email": payload.get("sub") or payload.get("email"), "role": role, "token": token}
+    except JWTError:
+        return None
+
+
+@router.get("/student/dashboard", response_class=HTMLResponse)
+async def student_dashboard(request: Request):
+    user = get_user_from_cookie(request)
+    if not user:
+        return RedirectResponse(url="/login", status_code=303)
+
+    if user.get("role") != "student":
+        return RedirectResponse(url="/dashboard", status_code=303)
+
+    api_base = get_api_base_url(request)
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            f"{api_base}/student/assignments",
+            headers={"Authorization": f"Bearer {user['token']}"},
+        )
+
+    assignments = r.json() if r.status_code < 400 else []
+    return templates.TemplateResponse(
+        "student_dashboard.html",
+        {"request": request, "user": user, "assignments": assignments},
+    )

--- a/app/templates/instructor_dashboard.html
+++ b/app/templates/instructor_dashboard.html
@@ -4,8 +4,11 @@
 
 <p>Signed in as: <b>{{ user.email }}</b></p>
 
-<p><a class="btn" href="/web/instructor/assignments/new">+ Create Assignment</a></p>
-
+<p>
+  <a class="btn" href="/web/instructor/assignments/new">
+    + Create Assignment
+  </a>
+</p>
 
 <h3>Your Assignments</h3>
 
@@ -20,20 +23,47 @@
       <th>Published</th>
       <th>Actions</th>
     </tr>
+
     {% for a in assignments %}
     <tr>
       <td>{{ a.id }}</td>
       <td>{{ a.title }}</td>
       <td>{{ a.language }}</td>
-      <td>{{ a.is_published }}</td>
+      <td>
+        {% if a.is_published %}
+          <span style="color:green;">Yes</span>
+        {% else %}
+          <span style="color:orange;">No</span>
+        {% endif %}
+      </td>
+
       <td>
         <a href="/web/instructor/assignments/{{ a.id }}/edit">Edit</a> |
         <a href="/web/instructor/assignments/{{ a.id }}/io-tests">IO Tests</a> |
-        <a href="/web/instructor/assignments/{{ a.id }}/unit-tests">Unit Tests</a>|
+        <a href="/web/instructor/assignments/{{ a.id }}/unit-tests">Unit Tests</a> |
         <a href="/web/instructor/assignments/{{ a.id }}/static-rules">Static Rules</a>
+
+        {% if not a.is_published %}
+          |
+          <form method="post"
+                action="/web/instructor/assignments/{{ a.id }}/publish"
+                style="display:inline;"
+                onsubmit="return confirm('Publish this assignment? Students will be able to see it and submit solutions.');">
+            <button type="submit">Publish</button>
+          </form>
+        {% else %}
+          |
+          <form method="post"
+                action="/web/instructor/assignments/{{ a.id }}/unpublish"
+                style="display:inline;"
+                onsubmit="return confirm('Unpublish this assignment? Students will no longer see it.');">
+            <button type="submit">Unpublish</button>
+          </form>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}
+
   </table>
 {% endif %}
 {% endblock %}

--- a/app/templates/student_dashboard.html
+++ b/app/templates/student_dashboard.html
@@ -4,5 +4,28 @@
 
 <p>Welcome, {{ user.email }}</p>
 
-<p class="muted">Your assignments and submissions will appear here.</p>
+<h3>Published Assignments</h3>
+
+{% if assignments|length == 0 %}
+  <p class="muted">No published assignments yet.</p>
+{% else %}
+  <table>
+    <tr>
+      <th>ID</th>
+      <th>Title</th>
+      <th>Language</th>
+      <th>Action</th>
+    </tr>
+    {% for a in assignments %}
+    <tr>
+      <td>{{ a.id }}</td>
+      <td>{{ a.title }}</td>
+      <td>{{ a.language }}</td>
+      <td>
+        <a href="#">Open</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
…ly access

- Implemented publish mechanism to set is_published=true for assignments
- Added instructor-only endpoint to publish assignments
- Ensured unpublished assignments remain hidden from student-facing endpoints
- Updated validation and persistence for publish state changes
- Added/updated Jinja UI controls to publish assignments
- Ensured compatibility with JSON-based API requests

Published assignments are now eligible for student visibility and submissions.